### PR TITLE
Fix RST_STREAM when stream closing

### DIFF
--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -719,7 +719,7 @@ send_trailers(State, Trailers, Stream=#stream_state{connection=Pid,
     h2_connection:actually_send_trailers(Pid, StreamId, Trailers),
     case State of
         half_closed_remote ->
-            {next_state, closed, Stream};
+            {next_state, closed, Stream, 0};
         open ->
             {next_state, half_closed_local, Stream}
     end.


### PR DESCRIPTION
Fixes an issue where a RST_STREAM message is sent each time a
stream is closed. As was the case with the code prior to hpack
dynamic table concurrency fixes, sending trailers in
half_closed_remote state should transfer the state to closed with
a timeout action.